### PR TITLE
feat: add text parser

### DIFF
--- a/tapservicego/internal/parsers/csvparser.go
+++ b/tapservicego/internal/parsers/csvparser.go
@@ -33,7 +33,7 @@ import (
 func ParseCSV(data []map[string]interface{}) (string, error) {
 	var csvResult bytes.Buffer
 	w := csv.NewWriter(&csvResult)
-	err := parsedata(data, w)
+	err := parseCsvData(data, w)
 	if err != nil {
 		return "", err
 	}
@@ -66,14 +66,14 @@ func ParseTSV(data []map[string]interface{}) (string, error) {
 	var tsvResult bytes.Buffer
 	w := csv.NewWriter(&tsvResult)
 	w.Comma = '\t'
-	err := parsedata(data, w)
+	err := parseCsvData(data, w)
 	if err != nil {
 		return "", err
 	}
 	return tsvResult.String(), nil
 }
 
-func parsedata(data []map[string]interface{}, w *csv.Writer) error {
+func parseCsvData(data []map[string]interface{}, w *csv.Writer) error {
 	headers := getHeaders(data[0])
 	err := w.Write(headers)
 	if err != nil {

--- a/tapservicego/internal/parsers/textparser.go
+++ b/tapservicego/internal/parsers/textparser.go
@@ -1,1 +1,40 @@
 package parsers
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func ParseText(data []map[string]interface{}) string {
+	var textResult bytes.Buffer
+	parseTextData(data, &textResult)
+	return textResult.String()
+}
+
+func parseTextData(data []map[string]interface{}, buffer *bytes.Buffer) {
+	fmt.Fprintln(buffer, "# Results:")
+	fmt.Fprintln(buffer, "#")
+	fmt.Fprintln(buffer, "# Headers:")
+	headers := getHeaders(data[0])
+	header_line := "# "
+	for i, header := range headers {
+		if i == len(headers)-1 {
+			header_line += fmt.Sprintf("%v", header)
+			break
+		}
+		header_line += fmt.Sprintf("%v | ", header)
+	}
+	fmt.Fprintln(buffer, header_line)
+	for _, row := range data {
+		converted := convertRowValuesToString(row, headers)
+		row_line := ""
+		for i, value := range converted {
+			if i == len(converted)-1 {
+				row_line += fmt.Sprintf("%v", value)
+				break
+			}
+			row_line += fmt.Sprintf("%v | ", value)
+		}
+		fmt.Fprintln(buffer, row_line)
+	}
+}

--- a/tapservicego/internal/parsers/textparser_test.go
+++ b/tapservicego/internal/parsers/textparser_test.go
@@ -1,0 +1,23 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseText(t *testing.T) {
+	data := []map[string]interface{}{
+		{"name": "Alice", "age": 30, "city": "New York"},
+		{"name": "Bob", "age": 25, "city": "Los Angeles"},
+	}
+	expected := `# Results:
+#
+# Headers:
+# age | city | name
+30 | New York | Alice
+25 | Los Angeles | Bob
+`
+	result := ParseText(data)
+	assert.Equal(t, expected, result)
+}

--- a/tapservicego/internal/tapsync/tapsync.go
+++ b/tapservicego/internal/tapsync/tapsync.go
@@ -53,7 +53,11 @@ func setResponse(c *gin.Context, sqlResult []map[string]interface{}, format stri
 		c.Header("Content-Length", fmt.Sprintf("%d", result.Len()))
 		c.Data(http.StatusOK, "application/fits", result.Bytes())
 	case "text":
-		return nil
+		result := parsers.ParseText(sqlResult)
+		c.Header("Content-Type", "text/plain")
+		c.Header("Content-Encoding", "UTF-8")
+		c.Header("Content-Length", fmt.Sprintf("%d", len(result)))
+		c.String(http.StatusOK, result)
 	case "html":
 		return nil
 	default:

--- a/tapservicego/internal/tapsync/tapsync_test.go
+++ b/tapservicego/internal/tapsync/tapsync_test.go
@@ -232,3 +232,22 @@ func TestFitsQueries(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 }
+
+func TestTextQueries(t *testing.T) {
+	t.Run("TestTextQuerySuccess", func(t *testing.T) {
+		db, err := GetDB(os.Getenv("DATABASE_URL"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		testhelpers.PopulateDb(db)
+		defer testhelpers.ClearDataFromTable(db)
+		service := NewTapSyncService()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("POST", "/sync", strings.NewReader("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM test"))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		service.Router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+		assert.Contains(t, w.Body.String(), "id | name | number")
+	})
+}


### PR DESCRIPTION
Adds plain text parser for sync queries.

The output for a query will look like this:
 
```
# Results
#
# Headers:
# column1 | column2 | column3
d11 | d12 | d13
d21 | d22 | d23
d31 | d32 | d33
...
```
Where lines starting with `#` are comments, usually containing metadata for the query.
Results are after the headers line and are separated by `|`