### PR TITLE
Alerce database experiment

### DIFF
--- a/tapservicego/dagger/main.go
+++ b/tapservicego/dagger/main.go
@@ -39,14 +39,14 @@ func (m *Tapservicego) BuildEnv(ctx context.Context, source *Directory) *Contain
 func (m *Tapservicego) Test(ctx context.Context, source *Directory) (string, error) {
 	db := dag.
 		Container().
-		From("index.docker.io/postgres").
-		WithEnvVariable("POSTGRES_USER", "postgres").
-		WithEnvVariable("POSTGRES_PASSWORD", "postgres").
+		From("docker.io/postgres:16-alpine").
+		WithEnvVariable("POSTGRES_USER", "testuser").
+		WithEnvVariable("POSTGRES_PASSWORD", "testpassword").
 		AsService()
 	return m.BuildEnv(ctx, source).
 		WithEnvVariable("ENV", "CI").
 		WithServiceBinding("db", db).
-		WithExec([]string{"go", "test", "./..."}).
+		WithExec([]string{"go", "test", "-failfast", "./..."}).
 		Stdout(ctx)
 }
 

--- a/tapservicego/internal/parsers/csvparser.go
+++ b/tapservicego/internal/parsers/csvparser.go
@@ -74,6 +74,9 @@ func ParseTSV(data []map[string]interface{}) (string, error) {
 }
 
 func parseCsvData(data []map[string]interface{}, w *csv.Writer) error {
+	if len(data) == 0 {
+		return nil
+	}
 	headers := getHeaders(data[0])
 	err := w.Write(headers)
 	if err != nil {

--- a/tapservicego/internal/parsers/fitsparser.go
+++ b/tapservicego/internal/parsers/fitsparser.go
@@ -99,6 +99,8 @@ func createColumns(data []map[string]interface{}) ([]fitsio.Column, error) {
 			format = "D" // 64-bit floating point
 		case string:
 			format = fmt.Sprintf("%dA", maxStringLength+1) // Character string with length
+		case bool:
+			format = "L" // logical
 		default:
 			return nil, fmt.Errorf("unsupported data type for column %s", key)
 		}

--- a/tapservicego/internal/parsers/fitsparser_test.go
+++ b/tapservicego/internal/parsers/fitsparser_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestParseFits(t *testing.T) {
 	data := []map[string]interface{}{
-		{"name": "Alice", "age": int64(30)},
-		{"name": "Bob", "age": int64(25)},
+		{"name": "Alice", "age": int64(30), "boolvalue": true},
+		{"name": "Bob", "age": int64(25), "boolvalue": false},
 	}
 	result, err := ParseFits(data)
 	assert.Nil(t, err)
@@ -25,7 +25,7 @@ func TestParseFits(t *testing.T) {
 	table := hdu.(*fitsio.Table)
 	assert.True(t, table.Type() == fitsio.BINARY_TBL)
 	assert.Equal(t, "results", table.Name())
-	assert.Equal(t, 2, table.NumCols())
+	assert.Equal(t, 3, table.NumCols())
 	assert.Equal(t, int64(2), table.NumRows())
 	rows, err := table.Read(0, table.NumRows())
 	assert.Nil(t, err)
@@ -38,6 +38,7 @@ func TestParseFits(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, data[count]["name"], row["name"])
 		assert.Equal(t, data[count]["age"], row["age"])
+		assert.Equal(t, data[count]["boolvalue"], row["boolvalue"])
 		parsedData = append(parsedData, row)
 		count = count + 1
 	}
@@ -74,4 +75,31 @@ func TestCreateFits(t *testing.T) {
 	assert.Equal(t, "name", result.Col(1).Name)
 	assert.Equal(t, "K", result.Col(0).Format)
 	assert.Equal(t, "6A", result.Col(1).Format)
+}
+
+func TestCreateColumnsWithBoolean(t *testing.T) {
+	data := []map[string]interface{}{
+		{"boolvalue": true},
+		{"boolvalue": false},
+	}
+	col, err := createColumns(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, col)
+	assert.Equal(t, 1, len(col))
+	assert.Equal(t, "boolvalue", col[0].Name)
+	assert.Equal(t, "L", col[0].Format)
+}
+
+func TestCreateFitsWithBoolean(t *testing.T) {
+	data := []map[string]interface{}{
+		{"boolvalue": true},
+		{"boolvalue": false},
+	}
+	result, err := CreateFits(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, "results", result.Name())
+	assert.Equal(t, 1, result.NumCols())
+	assert.Equal(t, "boolvalue", result.Col(0).Name)
+	assert.Equal(t, "L", result.Col(0).Format)
 }

--- a/tapservicego/internal/tapsync/alercecsv_test.go
+++ b/tapservicego/internal/tapsync/alercecsv_test.go
@@ -1,0 +1,206 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"ataps/pkg/alercedb"
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCsv(t *testing.T) {
+	test_get_csv_data_from_object := func(t *testing.T, table string, ensureObjectExistIn *string, overrideOid *string) [][]string {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		var oid string
+		if overrideOid == nil {
+			if ensureObjectExistIn == nil {
+				row := db.QueryRow("SELECT oid FROM object LIMIT 1")
+				if row.Err() != nil {
+					t.Fatal(row.Err())
+				}
+				row.Scan(&oid)
+			} else {
+				row := db.QueryRow(fmt.Sprintf("SELECT oid FROM %s LIMIT 1", *ensureObjectExistIn))
+				if row.Err() != nil {
+					t.Fatal(row.Err())
+				}
+				row.Scan(&oid)
+			}
+		} else {
+			oid = *overrideOid
+		}
+		service := NewTapSyncService()
+		response := sendTestQuery(fmt.Sprintf("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM %s WHERE oid='%s'", table, oid), service)
+		require.Equal(t, http.StatusOK, response.Code)
+		reader := csv.NewReader(response.Body)
+		records, err := reader.ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return records
+	}
+
+	t.Run("TestCsv_Detections", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM detection LIMIT 1", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		columnNames := getColumnNames(alercedb.Detection{})
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+
+	})
+
+	t.Run("TestCsv_DetectionsFromAnObject", func(t *testing.T) {
+		ensureObjectExistIn := "detection"
+		records := test_get_csv_data_from_object(t, "detection", &ensureObjectExistIn, nil)
+		require.Greater(t, len(records), 1)
+	})
+
+	t.Run("TestCsv_DetectionsFromUnknownObject", func(t *testing.T) {
+		var oid = "unknown"
+		records := test_get_csv_data_from_object(t, "detection", nil, &oid)
+		require.Equal(t, 0, len(records))
+	})
+
+	t.Run("TestCsv_NonDetection", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM non_detection LIMIT 1", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		columnNames := getColumnNames(alercedb.NonDetection{})
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+	})
+
+	t.Run("TestCsv_NonDetectionFromAnObject", func(t *testing.T) {
+		oidFrom := "non_detection"
+		records := test_get_csv_data_from_object(t, "non_detection", &oidFrom, nil)
+		require.Greater(t, len(records), 1)
+	})
+
+	t.Run("TestCsv_NonDetectionFromUnknownObject", func(t *testing.T) {
+		var oid = "unknown"
+		records := test_get_csv_data_from_object(t, "non_detection", nil, &oid)
+		require.Equal(t, 0, len(records))
+	})
+
+	t.Run("TestCsv_ForcedPhotometry", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM forced_photometry LIMIT 1", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		columnNames := getColumnNames(alercedb.ForcedPhotometry{})
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+	})
+
+	t.Run("TestCsv_ForcedPhotometryFromAnObject", func(t *testing.T) {
+		oidFrom := "forced_photometry"
+		records := test_get_csv_data_from_object(t, "forced_photometry", &oidFrom, nil)
+		require.Greater(t, len(records), 1)
+	})
+
+	t.Run("TestCsv_ForcedPhotometryFromUnknownObject", func(t *testing.T) {
+		var oid = "unknown"
+		records := test_get_csv_data_from_object(t, "forced_photometry", nil, &oid)
+		require.Equal(t, 0, len(records))
+	})
+
+	t.Run("TestCsv_Features", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM feature LIMIT 1", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		columnNames := getColumnNames(alercedb.Feature{})
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+	})
+
+	t.Run("TestCsv_FeaturesFromAnObject", func(t *testing.T) {
+		oidFrom := "feature"
+		records := test_get_csv_data_from_object(t, "feature", &oidFrom, nil)
+		require.Greater(t, len(records), 1)
+	})
+
+	t.Run("TestCsv_FeaturesFromUnknownObject", func(t *testing.T) {
+		var oid = "unknown"
+		records := test_get_csv_data_from_object(t, "feature", nil, &oid)
+		require.Equal(t, 0, len(records))
+	})
+
+	t.Run("TestCsv_Objects", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM object LIMIT 2", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		columnNames := getColumnNames(alercedb.Object{})
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+		require.Equal(t, 3, len(records)) // header + 2 objects
+	})
+
+	t.Run("TestCsv_Probabilities", func(t *testing.T) {
+		testhelpers.ClearALeRCEDB()
+		db := populateAlerceDB()
+		defer db.Close()
+		service := NewTapSyncService()
+		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM probability LIMIT 1", service)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
+		columnNames := getColumnNames(alercedb.Probability{})
+		records, err := csv.NewReader(w.Body).ReadAll()
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(columnNames)
+		require.Equal(t, columnNames, records[0])
+	})
+
+	t.Run("TestCsv_ProbabilitiesFromAnObject", func(t *testing.T) {
+		oidFrom := "probability"
+		records := test_get_csv_data_from_object(t, "probability", &oidFrom, nil)
+		require.Greater(t, len(records), 1)
+	})
+}

--- a/tapservicego/internal/tapsync/alercefits_test.go
+++ b/tapservicego/internal/tapsync/alercefits_test.go
@@ -1,0 +1,189 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"ataps/pkg/alercedb"
+	"net/http"
+	"testing"
+
+	"github.com/dirodriguezm/fitsio"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFits_Object(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM object LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 10, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.Object{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func TestFits_Detection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 19, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.Detection{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func TestFits_NonDetection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 4, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.NonDetection{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func TestFits_ForcedPhotometry(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 19, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func TestFits_Features(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM feature LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 5, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.Feature{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func TestFits_Probabilities(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=fits&&QUERY=SELECT * FROM probability LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/fits", w.Header().Get("Content-Type"))
+	f, err := fitsio.Open(w.Body)
+	require.Nil(t, err)
+	defer f.Close()
+	hdu := f.HDU(1)
+	table := hdu.(*fitsio.Table)
+	require.True(t, table.Type() == fitsio.BINARY_TBL)
+	require.Equal(t, "results", table.Name())
+	require.Equal(t, 6, table.NumCols())
+	require.Equal(t, int64(3), table.NumRows())
+	rows, err := table.Read(0, table.NumRows())
+	require.Nil(t, err)
+	defer rows.Close()
+	count, parsedData := parseResponseData(t, rows)
+	columnNames := getColumnNames(alercedb.Probability{})
+	assertColumnsExist(t, columnNames, parsedData)
+	require.Equal(t, 3, count)
+}
+
+func parseResponseData(t *testing.T, rows *fitsio.Rows) (int, []map[string]interface{}) {
+	parsedData := []map[string]interface{}{}
+	count := 0
+	for rows.Next() {
+		row := map[string]interface{}{}
+		err := rows.Scan(&row)
+		require.Nil(t, err)
+		parsedData = append(parsedData, row)
+		count = count + 1
+	}
+	return count, parsedData
+}
+
+func assertColumnsExist(t *testing.T, columnNames []string, parsedData []map[string]interface{}) {
+	for _, data := range parsedData {
+		for _, columnName := range columnNames {
+			_, ok := data[columnName]
+			require.True(t, ok)
+		}
+	}
+}

--- a/tapservicego/internal/tapsync/alercehtml_test.go
+++ b/tapservicego/internal/tapsync/alercehtml_test.go
@@ -1,0 +1,179 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"ataps/pkg/alercedb"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/html"
+)
+
+func TestHtml_Object(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM object LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Object{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestHtml_NonExistentTable(t *testing.T) {
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_existent_table LIMIT 3", service)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHtml_Detection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Detection{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestHtml_NonDetection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.NonDetection{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestHtml_ForcedPhotometry(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestHtml_Features(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM feature LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Feature{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestHtml_Probabilities(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM probability LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	doc, err := html.Parse(w.Body)
+	require.NoError(t, err)
+	parseHTMLTable(doc, &headers, "th")
+	parseHTMLTable(doc, &data, "td")
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Probability{})
+	require.ElementsMatch(t, headers, columnNames)
+}

--- a/tapservicego/internal/tapsync/alercetext_test.go
+++ b/tapservicego/internal/tapsync/alercetext_test.go
@@ -1,0 +1,160 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"ataps/pkg/alercedb"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestText_Object(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM object LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Object{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestText_Detection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Detection{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestText_NonDetection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.NonDetection{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestText_ForcedPhotometry(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestText_Features(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM feature LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Feature{})
+	require.ElementsMatch(t, headers, columnNames)
+}
+
+func TestText_Probabilities(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM probability LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+	var data []string
+	var headers []string
+	err := parseTextTable(w.Body.String(), &data, &headers)
+	require.NoError(t, err)
+	var rows []map[string]string
+	for i := 0; i < len(data); i += len(headers) {
+		row := make(map[string]string)
+		for j, header := range headers {
+			row[header] = data[i+j]
+		}
+		rows = append(rows, row)
+	}
+	require.Len(t, rows, 3)
+	columnNames := getColumnNames(alercedb.Probability{})
+	require.ElementsMatch(t, headers, columnNames)
+}

--- a/tapservicego/internal/tapsync/alercevotable_test.go
+++ b/tapservicego/internal/tapsync/alercevotable_test.go
@@ -1,0 +1,119 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"ataps/pkg/alercedb"
+	"ataps/pkg/votable"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVotable_Object(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM object LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.Object{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}
+
+func TestVotable_Detection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.Detection{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}
+
+func TestVotable_NonDetection(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.NonDetection{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}
+
+func TestVotable_ForcedPhotometry(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}
+
+func TestVotable_Features(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM feature LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.Feature{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}
+
+func TestVotable_Probabilities(t *testing.T) {
+	testhelpers.ClearALeRCEDB()
+	db := populateAlerceDB()
+	defer db.Close()
+	service := NewTapSyncService()
+	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM probability LIMIT 3", service)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+	voTable, err := votable.NewVOTableFromString(w.Body.String())
+	require.NoError(t, err)
+	columnNames := getColumnNames(alercedb.Probability{})
+	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	for _, field := range voTable.Resource.Tables[0].Fields {
+		require.Contains(t, columnNames, field.Name)
+	}
+	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+}

--- a/tapservicego/internal/tapsync/test_utils.go
+++ b/tapservicego/internal/tapsync/test_utils.go
@@ -1,0 +1,106 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"bufio"
+	"database/sql"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+func populateAlerceDB() *sql.DB {
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = testhelpers.PopulateALeRCEDB(db)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return db
+}
+
+func sendTestQuery(query string, service *TapSyncService) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(
+		"POST",
+		"/sync",
+		strings.NewReader(query),
+	)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	service.Router.ServeHTTP(w, req)
+	return w
+}
+
+func getColumnNames(v interface{}) []string {
+	t := reflect.TypeOf(v)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	var fieldNames []string
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		columnTag := field.Tag.Get("db")
+		if columnTag != "" {
+			columnName := strings.Split(columnTag, ",")[0]
+			fieldNames = append(fieldNames, columnName)
+		} else {
+			fieldNames = append(fieldNames, field.Name)
+		}
+	}
+
+	return fieldNames
+}
+
+func parseHTMLTable(doc *html.Node, data *[]string, tag string) {
+	var traverse func(n *html.Node, tag string) *html.Node
+	traverse = func(n *html.Node, tag string) *html.Node {
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type == html.TextNode && c.Parent.Data == tag {
+				*data = append(*data, c.Data)
+			}
+			res := traverse(c, tag)
+			if res != nil {
+				return res
+			}
+		}
+		return nil
+	}
+	traverse(doc, tag)
+}
+
+func parseTextTable(doc string, data *[]string, headers *[]string) error {
+	scanner := bufio.NewScanner(strings.NewReader(doc))
+	isHeader := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		isComment := strings.HasPrefix(line, "#")
+		if isComment {
+			if isHeader {
+				h := strings.Split(line, "|")
+				for _, header := range h {
+					header = strings.Replace(header, "#", "", -1)
+					*headers = append(*headers, strings.TrimSpace(header))
+				}
+			}
+			isHeader = strings.Contains(line, "Headers")
+		} else {
+			row := strings.Split(line, "|")
+			for _, cell := range row {
+				*data = append(*data, strings.TrimSpace(cell))
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tapservicego/internal/testhelpers/populatepsql.go
+++ b/tapservicego/internal/testhelpers/populatepsql.go
@@ -1,6 +1,22 @@
 package testhelpers
 
-import "database/sql"
+import (
+	"ataps/pkg/alercedb"
+	"database/sql"
+	"os"
+)
+
+func GetDB(url string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", url)
+	if err != nil {
+		return nil, err
+	}
+	err = db.Ping()
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
 
 func PopulateDb(db *sql.DB) error {
 	_, err := db.Exec("CREATE TABLE IF NOT EXISTS test (id SERIAL PRIMARY KEY, name TEXT, number INT)")
@@ -16,6 +32,56 @@ func PopulateDb(db *sql.DB) error {
 
 func ClearDataFromTable(db *sql.DB) error {
 	_, err := db.Exec("DELETE FROM test")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func PopulateALeRCEDB(db *sql.DB) error {
+	err := alercedb.CreateTables(db)
+	if err != nil {
+		return err
+	}
+	oidPool, err := alercedb.InsertSampleObjects(db, 100)
+	if err != nil {
+		return err
+	}
+	err = alercedb.InsertSampleDetections(db, 1000, oidPool)
+	if err != nil {
+		return err
+	}
+	err = alercedb.InsertSampleNonDetections(db, 1000, oidPool)
+	if err != nil {
+		return err
+	}
+	err = alercedb.InsertSampleForcedPhotometry(db, 1000, oidPool)
+	if err != nil {
+		return err
+	}
+	err = alercedb.InsertSampleFeatures(db, 100, oidPool)
+	if err != nil {
+		return err
+	}
+	err = alercedb.InsertSampleProbabilities(db, oidPool, []string{"SN", "AGN", "VS", "Asteroid", "Bogus"}, "stamp_classifier")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ClearALeRCEDB() error {
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = db.Exec("DISCARD ALL")
+	if err != nil {
+		return err
+	}
+	err = alercedb.DropTables(db)
 	if err != nil {
 		return err
 	}

--- a/tapservicego/pkg/alercedb/generators.go
+++ b/tapservicego/pkg/alercedb/generators.go
@@ -1,0 +1,196 @@
+package alercedb
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"sort"
+)
+
+// GenerateObjects creates a slice of Object structs
+// with the provided number of objects
+// and each object is created with random values
+func generateObjects(number int) []Object {
+	objects := make([]Object, number)
+	for i := 1; i <= number; i++ {
+		oid := fmt.Sprintf("oid%d", i)
+		meanRA := rand.Float64() * 360
+		meanDec := rand.Float64() * 180
+		sigmaRA := rand.Float64() * 10
+		sigmaDec := rand.Float64() * 10
+		firstMJD := rand.Float64() * 10000
+		lastMJD := firstMJD + rand.Float64()*100
+		nDet := rand.IntN(1000)
+		stellar := rand.IntN(2) == 1
+		corrected := rand.IntN(2) == 1
+		objects[i-1] = Object{
+			Oid:       oid,
+			MeanRA:    meanRA,
+			MeanDec:   meanDec,
+			SigmaRA:   sigmaRA,
+			SigmaDec:  sigmaDec,
+			FirstMJD:  firstMJD,
+			LastMJD:   lastMJD,
+			NDet:      nDet,
+			Stellar:   stellar,
+			Corrected: corrected,
+		}
+	}
+	return objects
+}
+
+// generateDetections creates a slice of Detection structs
+func generateDetections(number int, oidPool []string) []Detection {
+	detections := make([]Detection, number)
+	for i := 0; i < number; i++ {
+		candid := i + 100001
+		oid := oidPool[rand.IntN(len(oidPool))]
+		mjd := rand.Float64() * 10000
+		fid := rand.IntN(5)
+		pid := rand.Float64() * 10000
+		diffmaglim := rand.Float64() * 100
+		isdiffpos := rand.IntN(2)
+		ra := rand.Float64() * 360
+		dec := rand.Float64() * 180
+		magpsf := rand.Float64() * 100
+		sigmapsf := rand.Float64() * 100
+		magpsfCorr := rand.Float64() * 100
+		sigmapsfCorr := rand.Float64() * 100
+		sigmapsfCorrExt := rand.Float64() * 100
+		distnr := rand.Float64() * 100
+		corrected := rand.IntN(2) == 1
+		dubious := rand.IntN(2) == 1
+		parentCandid := rand.IntN(100000)
+		hasStamp := rand.IntN(2) == 1
+		detections[i] = Detection{
+			Candid:          candid,
+			Oid:             oid,
+			MJD:             mjd,
+			FID:             fid,
+			PID:             pid,
+			Diffmaglim:      diffmaglim,
+			Isdiffpos:       isdiffpos,
+			RA:              ra,
+			Dec:             dec,
+			Magpsf:          magpsf,
+			Sigmapsf:        sigmapsf,
+			MagpsfCorr:      magpsfCorr,
+			SigmapsfCorr:    sigmapsfCorr,
+			SigmapsfCorrExt: sigmapsfCorrExt,
+			Distnr:          distnr,
+			Corrected:       corrected,
+			Dubious:         dubious,
+			ParentCandid:    parentCandid,
+			HasStamp:        hasStamp,
+		}
+	}
+	return detections
+}
+
+// generateNonDetections creates a slice of NonDetection structs
+func generateNonDetections(number int, oidPool []string) []NonDetection {
+	nonDetections := make([]NonDetection, number)
+	for i := 0; i < number; i++ {
+		oid := oidPool[rand.IntN(len(oidPool))]
+		fid := rand.IntN(5)
+		mjd := rand.Float64() * 10000
+		diffmaglim := rand.Float64() * 100
+		nonDetections[i] = NonDetection{
+			Oid:        oid,
+			Fid:        fid,
+			Mjd:        mjd,
+			Diffmaglim: diffmaglim,
+		}
+	}
+	return nonDetections
+}
+
+// generateForcedPhotometry creates a slice of ForcedPhotometry structs
+func generateForcedPhotometry(number int, oidPool []string) []ForcedPhotometry {
+	forcedPhotometry := make([]ForcedPhotometry, number)
+	for i := 0; i < number; i++ {
+		candid := i + 100001
+		oid := oidPool[rand.IntN(len(oidPool))]
+		mjd := rand.Float64() * 10000
+		fid := rand.IntN(5)
+		pid := rand.Float64() * 10000
+		diffmaglim := rand.Float64() * 100
+		isdiffpos := rand.IntN(2)
+		ra := rand.Float64() * 360
+		dec := rand.Float64() * 180
+		magpsf := rand.Float64() * 100
+		sigmapsf := rand.Float64() * 100
+		magpsfCorr := rand.Float64() * 100
+		sigmapsfCorr := rand.Float64() * 100
+		sigmapsfCorrExt := rand.Float64() * 100
+		distnr := rand.Float64() * 100
+		corrected := rand.IntN(2) == 1
+		dubious := rand.IntN(2) == 1
+		parentCandid := rand.IntN(100000)
+		hasStamp := rand.IntN(2) == 1
+		forcedPhotometry[i] = ForcedPhotometry{
+			Candid:          candid,
+			Oid:             oid,
+			MJD:             mjd,
+			FID:             fid,
+			PID:             pid,
+			Diffmaglim:      diffmaglim,
+			Isdiffpos:       isdiffpos,
+			RA:              ra,
+			Dec:             dec,
+			Magpsf:          magpsf,
+			Sigmapsf:        sigmapsf,
+			MagpsfCorr:      magpsfCorr,
+			SigmapsfCorr:    sigmapsfCorr,
+			SigmapsfCorrExt: sigmapsfCorrExt,
+			Distnr:          distnr,
+			Corrected:       corrected,
+			Dubious:         dubious,
+			ParentCandid:    parentCandid,
+			HasStamp:        hasStamp,
+		}
+	}
+	return forcedPhotometry
+}
+
+// generateFeatures creates a slice of Feature structs
+func generateFeatures(number int, oidPool []string) []Feature {
+	features := make([]Feature, number)
+	for i := 0; i < number; i++ {
+		oid := oidPool[rand.IntN(len(oidPool))]
+		name := fmt.Sprintf("feature%d", i)
+		value := rand.Float64() * 100
+		fid := rand.IntN(3) + 1
+		version := "test"
+		features[i] = Feature{
+			Oid:     oid,
+			Name:    name,
+			Value:   value,
+			Fid:     fid,
+			Version: version,
+		}
+	}
+	return features
+}
+
+// generateProbabilities creates a slice of Probability structs
+func generateProbabilities(oidPool []string, classesPool []string, classifierName string) []Probability {
+	probabilities := make([]Probability, len(oidPool)*len(classesPool))
+	probValues := make([]float64, len(classesPool))
+	for i := 0; i < len(classesPool); i++ {
+		probValues[i] = rand.Float64()
+	}
+	sort.Float64s(probValues)
+	for i := 0; i < len(oidPool); i++ {
+		for class := 0; class < len(classesPool); class++ {
+			probabilities[len(classesPool)*i+class] = Probability{
+				Oid:               oidPool[i],
+				ClassName:         classesPool[class],
+				ClassifierName:    classifierName,
+				ClassifierVersion: "1.0.0",
+				Probability:       probValues[class],
+				Ranking:           class + 1,
+			}
+		}
+	}
+	return probabilities
+}

--- a/tapservicego/pkg/alercedb/generators_test.go
+++ b/tapservicego/pkg/alercedb/generators_test.go
@@ -1,0 +1,50 @@
+package alercedb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateObjects(t *testing.T) {
+	objects := generateObjects(10)
+	assert.Equal(t, 10, len(objects))
+}
+
+func TestGenerateDetections(t *testing.T) {
+	oidPool := []string{"oid1", "oid2", "oid3", "oid4", "oid5"}
+	detections := generateDetections(10, oidPool)
+	assert.Equal(t, 10, len(detections))
+}
+
+func TestGenerateNonDetections(t *testing.T) {
+	oidPool := []string{"oid1", "oid2", "oid3", "oid4", "oid5"}
+	nonDetections := generateNonDetections(10, oidPool)
+	assert.Equal(t, 10, len(nonDetections))
+}
+
+func TestGenerateForcedPhotometry(t *testing.T) {
+	oidPool := []string{"oid1", "oid2", "oid3", "oid4", "oid5"}
+	forcedPhotometry := generateForcedPhotometry(10, oidPool)
+	assert.Equal(t, 10, len(forcedPhotometry))
+}
+
+func TestGenerateFeatures(t *testing.T) {
+	oidPool := []string{"oid1", "oid2", "oid3", "oid4", "oid5"}
+	features := generateFeatures(10, oidPool)
+	assert.Equal(t, 10, len(features))
+}
+
+func TestGenerateProbabilities(t *testing.T) {
+	oidPool := []string{"oid1", "oid2", "oid3", "oid4", "oid5"}
+	classes := []string{"class1", "class2", "class3", "class4", "class5"}
+	probabilities := generateProbabilities(oidPool, classes, "classifier")
+	assert.Equal(t, len(oidPool)*len(classes), len(probabilities))
+	for i, p := range probabilities {
+		assert.Equal(t, "classifier", p.ClassifierName)
+		assert.Contains(t, oidPool, p.Oid)
+		classIndex := i % len(classes)
+		assert.Equal(t, classes[classIndex], p.ClassName)
+		assert.Equal(t, classIndex, p.Ranking-1)
+	}
+}

--- a/tapservicego/pkg/alercedb/inserts.go
+++ b/tapservicego/pkg/alercedb/inserts.go
@@ -1,0 +1,280 @@
+package alercedb
+
+import (
+	"database/sql"
+)
+
+func InsertSampleDetections(db *sql.DB, number int, oidPool []string) error {
+	detections := generateDetections(number, oidPool)
+	err := insertDetections(detections, db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func InsertSampleObjects(db *sql.DB, number int) ([]string, error) {
+	objects := generateObjects(number)
+	oids := make([]string, len(objects))
+	for i, object := range objects {
+		oids[i] = object.Oid
+	}
+	err := insertObjects(objects, db)
+	if err != nil {
+		return nil, err
+	}
+	return oids, nil
+}
+
+func InsertSampleNonDetections(db *sql.DB, number int, oidPool []string) error {
+	nonDetections := generateNonDetections(number, oidPool)
+	err := insertNonDetections(nonDetections, db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func InsertSampleForcedPhotometry(db *sql.DB, number int, oidPool []string) error {
+	forcedPhotometry := generateForcedPhotometry(number, oidPool)
+	err := insertForcedPhotometry(forcedPhotometry, db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func InsertSampleFeatures(db *sql.DB, number int, oidPool []string) error {
+	features := generateFeatures(number, oidPool)
+	err := insertFeatures(features, db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func InsertSampleProbabilities(db *sql.DB, oidPool []string, classPool []string, classifierName string) error {
+	probabilities := generateProbabilities(oidPool, classPool, classifierName)
+	err := insertProbabilities(probabilities, db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// InsertObjects inserts the provided slice of objects
+// into the database using the provided database connection
+func insertObjects(objects []Object, db *sql.DB) error {
+	query := `INSERT INTO object (
+		oid,
+		meanra,
+		meandec,
+		sigmara,
+		sigmadec,
+		firstmjd,
+		lastmjd,
+		ndet,
+		stellar,
+		corrected
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);`
+	for _, object := range objects {
+		_, err := db.Exec(
+			query,
+			object.Oid,
+			object.MeanRA,
+			object.MeanDec,
+			object.SigmaRA,
+			object.SigmaDec,
+			object.FirstMJD,
+			object.LastMJD,
+			object.NDet,
+			object.Stellar,
+			object.Corrected,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Insert detections into the database
+func insertDetections(detections []Detection, db *sql.DB) error {
+	query := `INSERT INTO detection (
+		candid,
+		oid,
+		mjd,
+		fid,
+		pid,
+		diffmaglim,
+		isdiffpos,
+		ra,
+		dec,
+		magpsf,
+		sigmapsf,
+		magpsf_corr,
+		sigmapsf_corr,
+		sigmapsf_corr_ext,
+		distnr,
+		corrected,
+		dubious,
+		parent_candid,
+		has_stamp
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19);`
+	for _, detection := range detections {
+		_, err := db.Exec(
+			query,
+			detection.Candid,
+			detection.Oid,
+			detection.MJD,
+			detection.FID,
+			detection.PID,
+			detection.Diffmaglim,
+			detection.Isdiffpos,
+			detection.RA,
+			detection.Dec,
+			detection.Magpsf,
+			detection.Sigmapsf,
+			detection.MagpsfCorr,
+			detection.SigmapsfCorr,
+			detection.SigmapsfCorrExt,
+			detection.Distnr,
+			detection.Corrected,
+			detection.Dubious,
+			detection.ParentCandid,
+			detection.HasStamp,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// insertNonDetections inserts the provided slice of non-detections
+func insertNonDetections(nonDetections []NonDetection, db *sql.DB) error {
+	query := `INSERT INTO non_detection (
+		oid,
+		fid,
+		mjd,
+		diffmaglim
+	) VALUES ($1, $2, $3, $4);`
+	for _, nonDetection := range nonDetections {
+		_, err := db.Exec(
+			query,
+			nonDetection.Oid,
+			nonDetection.Fid,
+			nonDetection.Mjd,
+			nonDetection.Diffmaglim,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// insertForcedPhotometry inserts the provided slice of forced photometry
+func insertForcedPhotometry(forcedPhotometry []ForcedPhotometry, db *sql.DB) error {
+	query := `INSERT INTO forced_photometry (
+		candid,
+		oid,
+		mjd,
+		fid,
+		pid,
+		diffmaglim,
+		isdiffpos,
+		ra,
+		dec,
+		magpsf,
+		sigmapsf,
+		magpsf_corr,
+		sigmapsf_corr,
+		sigmapsf_corr_ext,
+		distnr,
+		corrected,
+		dubious,
+		parent_candid,
+		has_stamp
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19);`
+	for _, forcedPhotometry := range forcedPhotometry {
+		_, err := db.Exec(
+			query,
+			forcedPhotometry.Candid,
+			forcedPhotometry.Oid,
+			forcedPhotometry.MJD,
+			forcedPhotometry.FID,
+			forcedPhotometry.PID,
+			forcedPhotometry.Diffmaglim,
+			forcedPhotometry.Isdiffpos,
+			forcedPhotometry.RA,
+			forcedPhotometry.Dec,
+			forcedPhotometry.Magpsf,
+			forcedPhotometry.Sigmapsf,
+			forcedPhotometry.MagpsfCorr,
+			forcedPhotometry.SigmapsfCorr,
+			forcedPhotometry.SigmapsfCorrExt,
+			forcedPhotometry.Distnr,
+			forcedPhotometry.Corrected,
+			forcedPhotometry.Dubious,
+			forcedPhotometry.ParentCandid,
+			forcedPhotometry.HasStamp,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// insertFeatures inserts the provided slice of features
+func insertFeatures(features []Feature, db *sql.DB) error {
+	query := `INSERT INTO feature (
+		oid,
+		name,
+		value,
+		fid,
+		version
+	) VALUES ($1, $2, $3, $4, $5);`
+	for _, feature := range features {
+		_, err := db.Exec(
+			query,
+			feature.Oid,
+			feature.Name,
+			feature.Value,
+			feature.Fid,
+			feature.Version,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// insertProbabilities inserts the provided slice of probabilities
+func insertProbabilities(probabilities []Probability, db *sql.DB) error {
+	query := `INSERT INTO probability (
+		oid,
+		class_name,
+		classifier_name,
+		classifier_version,
+		probability,
+		ranking
+	) VALUES ($1, $2, $3, $4, $5, $6);`
+	for _, probability := range probabilities {
+		_, err := db.Exec(
+			query,
+			probability.Oid,
+			probability.ClassName,
+			probability.ClassifierName,
+			probability.ClassifierVersion,
+			probability.Probability,
+			probability.Ranking,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tapservicego/pkg/alercedb/inserts_test.go
+++ b/tapservicego/pkg/alercedb/inserts_test.go
@@ -1,0 +1,127 @@
+package alercedb
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsertSampleObjects(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	_, err = InsertSampleObjects(db, 10)
+	query := `SELECT COUNT(*) FROM object;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 10, count)
+}
+
+func TestInsertSampleDetections(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	oidPool, err := InsertSampleObjects(db, 10)
+	require.Nil(t, err)
+	err = InsertSampleDetections(db, 100, oidPool)
+	require.Nil(t, err)
+	query := `SELECT COUNT(*) FROM detection;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 100, count)
+}
+
+func TestInsertSampleNonDetections(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	oidPool, err := InsertSampleObjects(db, 10)
+	require.Nil(t, err)
+	err = InsertSampleNonDetections(db, 100, oidPool)
+	require.Nil(t, err)
+	query := `SELECT COUNT(*) FROM non_detection;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 100, count)
+}
+
+func TestInsertSampleForcedPhotometry(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	oidPool, err := InsertSampleObjects(db, 10)
+	require.Nil(t, err)
+	err = InsertSampleForcedPhotometry(db, 100, oidPool)
+	require.Nil(t, err)
+	query := `SELECT COUNT(*) FROM forced_photometry;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 100, count)
+}
+
+func TestInsertSampleFeatures(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	oidPool, err := InsertSampleObjects(db, 10)
+	require.Nil(t, err)
+	err = InsertSampleFeatures(db, 100, oidPool)
+	require.Nil(t, err)
+	query := `SELECT COUNT(*) FROM feature;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 100, count)
+}
+
+func TestInsertSampleProbabilities(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	require.Nil(t, err)
+	oidPool, err := InsertSampleObjects(db, 10)
+	require.Nil(t, err)
+	classPool := []string{"class1", "class2", "class3"}
+	err = InsertSampleProbabilities(db, oidPool, classPool, "classifier")
+	require.Nil(t, err)
+	query := `SELECT COUNT(*) FROM probability;`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, len(classPool)*len(oidPool), count)
+}

--- a/tapservicego/pkg/alercedb/models.go
+++ b/tapservicego/pkg/alercedb/models.go
@@ -1,0 +1,88 @@
+package alercedb
+
+// Object represents an object in the database
+type Object struct {
+	Oid       string  `db:"oid"`
+	MeanRA    float64 `db:"meanra"`
+	MeanDec   float64 `db:"meandec"`
+	SigmaRA   float64 `db:"sigmara"`
+	SigmaDec  float64 `db:"sigmadec"`
+	FirstMJD  float64 `db:"firstmjd"`
+	LastMJD   float64 `db:"lastmjd"`
+	NDet      int     `db:"ndet"`
+	Stellar   bool    `db:"stellar"`
+	Corrected bool    `db:"corrected"`
+}
+
+// Detection represents a detection in the database
+type Detection struct {
+	Candid          int     `db:"candid"`
+	Oid             string  `db:"oid"`
+	MJD             float64 `db:"mjd"`
+	FID             int     `db:"fid"`
+	PID             float64 `db:"pid"`
+	Diffmaglim      float64 `db:"diffmaglim"`
+	Isdiffpos       int     `db:"isdiffpos"`
+	RA              float64 `db:"ra"`
+	Dec             float64 `db:"dec"`
+	Magpsf          float64 `db:"magpsf"`
+	Sigmapsf        float64 `db:"sigmapsf"`
+	MagpsfCorr      float64 `db:"magpsf_corr"`
+	SigmapsfCorr    float64 `db:"sigmapsf_corr"`
+	SigmapsfCorrExt float64 `db:"sigmapsf_corr_ext"`
+	Distnr          float64 `db:"distnr"`
+	Corrected       bool    `db:"corrected"`
+	Dubious         bool    `db:"dubious"`
+	ParentCandid    int     `db:"parent_candid"`
+	HasStamp        bool    `db:"has_stamp"`
+}
+
+// NonDetection represents a non-detection in the database
+type NonDetection struct {
+	Oid        string  `db:"oid"`
+	Fid        int     `db:"fid"`
+	Mjd        float64 `db:"mjd"`
+	Diffmaglim float64 `db:"diffmaglim"`
+}
+
+// ForcedPhotometry represents a forced photometry in the database
+type ForcedPhotometry struct {
+	Candid          int     `db:"candid"`
+	Oid             string  `db:"oid"`
+	MJD             float64 `db:"mjd"`
+	FID             int     `db:"fid"`
+	PID             float64 `db:"pid"`
+	Diffmaglim      float64 `db:"diffmaglim"`
+	Isdiffpos       int     `db:"isdiffpos"`
+	RA              float64 `db:"ra"`
+	Dec             float64 `db:"dec"`
+	Magpsf          float64 `db:"magpsf"`
+	Sigmapsf        float64 `db:"sigmapsf"`
+	MagpsfCorr      float64 `db:"magpsf_corr"`
+	SigmapsfCorr    float64 `db:"sigmapsf_corr"`
+	SigmapsfCorrExt float64 `db:"sigmapsf_corr_ext"`
+	Distnr          float64 `db:"distnr"`
+	Corrected       bool    `db:"corrected"`
+	Dubious         bool    `db:"dubious"`
+	ParentCandid    int     `db:"parent_candid"`
+	HasStamp        bool    `db:"has_stamp"`
+}
+
+// Feature represents a feature in the database
+type Feature struct {
+	Oid     string  `db:"oid"`
+	Name    string  `db:"name"`
+	Value   float64 `db:"value"`
+	Fid     int     `db:"fid"`
+	Version string  `db:"version"`
+}
+
+// Probability represents a probability in the database
+type Probability struct {
+	Oid               string  `db:"oid"`
+	ClassName         string  `db:"class_name"`
+	ClassifierName    string  `db:"classifier_name"`
+	ClassifierVersion string  `db:"classifier_version"`
+	Probability       float64 `db:"probability"`
+	Ranking           int     `db:"ranking"`
+}

--- a/tapservicego/pkg/alercedb/tables.go
+++ b/tapservicego/pkg/alercedb/tables.go
@@ -1,0 +1,244 @@
+package alercedb
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func CreateTables(db *sql.DB) error {
+	err := createObjectTable(db)
+	if err != nil {
+		return err
+	}
+	err = createDetectionsTable(db)
+	if err != nil {
+		return err
+	}
+	err = createNonDetectionsTable(db)
+	if err != nil {
+		return err
+	}
+	err = createForcedPhotometryTable(db)
+	if err != nil {
+		return err
+	}
+	err = createFeaturesTable(db)
+	if err != nil {
+		return err
+	}
+	err = createProbabilitiesTable(db)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func DropTables(db *sql.DB) error {
+	_, err := db.Exec(`
+		DROP SCHEMA public CASCADE;
+		CREATE SCHEMA public;
+		GRANT ALL ON SCHEMA public TO testuser;
+		GRANT ALL ON SCHEMA public TO public;
+		`)
+	return err
+}
+
+func createObjectTable(db *sql.DB) error {
+	query := `CREATE TABLE object (
+		oid VARCHAR(12) PRIMARY KEY,
+		meanra DOUBLE PRECISION NOT NULL,
+		meandec DOUBLE PRECISION NOT NULL,
+		sigmara DOUBLE PRECISION NOT NULL,
+		sigmadec DOUBLE PRECISION NOT NULL,
+		firstmjd DOUBLE PRECISION NOT NULL,
+		lastmjd DOUBLE PRECISION NOT NULL,
+		ndet INTEGER NOT NULL,
+		stellar BOOLEAN NOT NULL,
+		corrected BOOLEAN NOT NULL
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_object_ndet", "object", "oid")
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_object_firstmjd", "object", "firstmjd")
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_object_meanra", "object", "meanra")
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_object_meandec", "object", "meandec")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create detections table
+func createDetectionsTable(db *sql.DB) error {
+	query := `CREATE TABLE IF NOT EXISTS detection (
+		candid BIGINT,
+		oid VARCHAR(12),
+		mjd DOUBLE PRECISION NOT NULL,
+		fid INTEGER NOT NULL,
+		pid DOUBLE PRECISION NOT NULL,
+		diffmaglim DOUBLE PRECISION,
+		isdiffpos SMALLINT NOT NULL,
+		ra DOUBLE PRECISION NOT NULL,
+		dec DOUBLE PRECISION NOT NULL,
+		magpsf DOUBLE PRECISION NOT NULL,
+		sigmapsf DOUBLE PRECISION NOT NULL,
+		magpsf_corr DOUBLE PRECISION, 
+		sigmapsf_corr DOUBLE PRECISION,
+		sigmapsf_corr_ext DOUBLE PRECISION,
+		distnr DOUBLE PRECISION,
+		corrected BOOLEAN NOT NULL,
+		dubious BOOLEAN NOT NULL,
+		parent_candid BIGINT,
+		has_stamp BOOLEAN NOT NULL,
+		PRIMARY KEY (candid, oid),
+		FOREIGN KEY (oid) REFERENCES object(oid)
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndexUsing(db, "ix_detection_oid", "detection", "oid", "hash")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createNonDetectionsTable(db *sql.DB) error {
+	query := `CREATE TABLE IF NOT EXISTS non_detection (
+		oid VARCHAR(12),
+		fid INTEGER NOT NULL,
+		mjd DOUBLE PRECISION NOT NULL,
+		diffmaglim DOUBLE PRECISION,
+		PRIMARY KEY (oid, fid, mjd),
+		FOREIGN KEY (oid) REFERENCES object(oid)
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndexUsing(db, "ix_nondetection_oid", "non_detection", "oid", "hash")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createForcedPhotometryTable(db *sql.DB) error {
+	query := `CREATE TABLE IF NOT EXISTS forced_photometry (
+		candid BIGINT,
+		oid VARCHAR(12),
+		mjd DOUBLE PRECISION NOT NULL,
+		fid INTEGER NOT NULL,
+		pid DOUBLE PRECISION NOT NULL,
+		diffmaglim DOUBLE PRECISION,
+		isdiffpos SMALLINT NOT NULL,
+		ra DOUBLE PRECISION NOT NULL,
+		dec DOUBLE PRECISION NOT NULL,
+		magpsf DOUBLE PRECISION NOT NULL,
+		sigmapsf DOUBLE PRECISION NOT NULL,
+		magpsf_corr DOUBLE PRECISION, 
+		sigmapsf_corr DOUBLE PRECISION,
+		sigmapsf_corr_ext DOUBLE PRECISION,
+		distnr DOUBLE PRECISION,
+		corrected BOOLEAN NOT NULL,
+		dubious BOOLEAN NOT NULL,
+		parent_candid BIGINT,
+		has_stamp BOOLEAN NOT NULL,
+		PRIMARY KEY (candid, oid),
+		FOREIGN KEY (oid) REFERENCES object(oid)
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndexUsing(db, "ix_forced_photometry_oid", "forced_photometry", "oid", "hash")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createFeaturesTable(db *sql.DB) error {
+	query := `CREATE TABLE IF NOT EXISTS feature (
+		oid VARCHAR(12),
+		name VARCHAR(255) NOT NULL,
+		value DOUBLE PRECISION,
+		fid INTEGER NOT NULL,
+		version VARCHAR(16) NOT NULL,
+		PRIMARY KEY (oid, name, fid, version),
+		FOREIGN KEY (oid) REFERENCES object(oid)
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndexUsing(db, "ix_feature_oid_2", "feature", "oid", "hash")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createProbabilitiesTable(db *sql.DB) error {
+	query := `CREATE TABLE IF NOT EXISTS probability (
+		oid VARCHAR(12),
+		class_name VARCHAR(255) NOT NULL,
+		classifier_name VARCHAR(255) NOT NULL,
+		classifier_version VARCHAR(16) NOT NULL,
+		probability DOUBLE PRECISION NOT NULL,
+		ranking INTEGER NOT NULL,
+		PRIMARY KEY (oid, class_name, classifier_name, classifier_version),
+		FOREIGN KEY (oid) REFERENCES object(oid)
+	);`
+	_, err := db.Exec(query)
+	if err != nil {
+		return err
+	}
+	err = createIndexUsing(db, "ix_probability_oid", "probability", "oid", "hash")
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_probability_probability", "probability", "probability")
+	if err != nil {
+		return err
+	}
+	err = createIndex(db, "ix_probability_ranking", "probability", "ranking")
+	if err != nil {
+		return err
+	}
+	err = createIndexWhere(db, "ix_probability_ranking_1", "probability", "ranking", "ranking = 1")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createIndex(db *sql.DB, index_name string, table string, column string) error {
+	query := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (%s);", index_name, table, column)
+	_, err := db.Exec(query)
+	return err
+}
+
+func createIndexUsing(db *sql.DB, index_name string, table string, column string, using string) error {
+	query := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s USING %s (%s);", index_name, table, using, column)
+	_, err := db.Exec(query)
+	return err
+}
+
+func createIndexWhere(db *sql.DB, index_name string, table string, column string, where string) error {
+	query := fmt.Sprintf("CREATE INDEX IF NOT EXISTS %s ON %s (%s) WHERE %s;", index_name, table, column, where)
+	_, err := db.Exec(query)
+	return err
+}

--- a/tapservicego/pkg/alercedb/tables_test.go
+++ b/tapservicego/pkg/alercedb/tables_test.go
@@ -1,0 +1,218 @@
+package alercedb
+
+import (
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTables(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = CreateTables(db)
+	assert.Nil(t, err)
+	assertTableExists("object", db, t)
+	assertTableExists("detection", db, t)
+	assertTableExists("non_detection", db, t)
+}
+
+func TestCreateObjectsTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	assert.Nil(t, err)
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	assertTableExists("object", db, t)
+}
+
+func TestCreateObjectsTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'object'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, count)
+}
+
+func TestCreateDetectionsTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createDetectionsTable(db)
+	assert.Nil(t, err)
+	assertTableExists("detection", db, t)
+}
+
+func TestCreateDetectionsTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createDetectionsTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'detection'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCreateNonDetectionsTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createNonDetectionsTable(db)
+	assert.Nil(t, err)
+	assertTableExists("non_detection", db, t)
+}
+
+func TestCreateNonDetectionsTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createNonDetectionsTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'non_detection'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCreateForcedPhotometryTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createForcedPhotometryTable(db)
+	assert.Nil(t, err)
+	assertTableExists("forced_photometry", db, t)
+}
+func TestCreateForcedPhotometryTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createForcedPhotometryTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'forced_photometry'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCreateFeatureTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createFeaturesTable(db)
+	assert.Nil(t, err)
+	assertTableExists("feature", db, t)
+}
+
+func TestCreateFeatureTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createFeaturesTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'feature'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCreateProbabilityTable(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createProbabilitiesTable(db)
+	assert.Nil(t, err)
+	assertTableExists("probability", db, t)
+}
+
+func TestCreateProbabilityTableIndex(t *testing.T) {
+	restoreDatabase()
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = createObjectTable(db)
+	assert.Nil(t, err)
+	err = createProbabilitiesTable(db)
+	assert.Nil(t, err)
+	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'probability'`
+	var count int
+	err = db.QueryRow(query).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, count)
+}
+
+func assertTableExists(tableName string, db *sql.DB, t *testing.T) {
+	query := `SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1;`
+	var count int
+	err := db.QueryRow(query, tableName).Scan(&count)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, count)
+}

--- a/tapservicego/pkg/alercedb/utils_test.go
+++ b/tapservicego/pkg/alercedb/utils_test.go
@@ -1,0 +1,137 @@
+package alercedb
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+var ctx context.Context
+var container *postgres.PostgresContainer
+
+func CreatePostgresContainer(ctx context.Context) (*postgres.PostgresContainer, error) {
+	postgresContainer, err := postgres.RunContainer(ctx,
+		testcontainers.WithImage("docker.io/postgres:16-alpine"),
+		postgres.WithDatabase("alercedb"),
+		postgres.WithUsername("testuser"),
+		postgres.WithPassword("testpassword"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(5*time.Second)),
+	)
+	if err != nil {
+		log.Printf("failed to start container: %s", err)
+		return nil, err
+	}
+	err = postgresContainer.Snapshot(ctx, postgres.WithSnapshotName("initial"))
+	if err != nil {
+		log.Printf("failed to snapshot container: %s", err)
+		return nil, err
+	}
+	return postgresContainer, nil
+}
+
+func CleanUpContainer(ctx context.Context, postgresContainer *postgres.PostgresContainer) {
+	if err := postgresContainer.Terminate(ctx); err != nil {
+		log.Fatalf("failed to terminate container: %s", err)
+	}
+}
+
+// GetDB creates a new database connection
+// using the provided URL
+// and returns a pointer to the connection
+// or an error if one occurs.
+// The URL should be in the format:
+// postgresql://user:password@host:port/database
+func GetDB(url string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", url)
+	if err != nil {
+		return nil, err
+	}
+	err = db.Ping()
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func initializeLocalDB() {
+	log.Println("Using local database")
+	var err error
+	ctx = context.Background()
+	container, err = CreatePostgresContainer(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var connStr string
+	connStr, err = container.ConnectionString(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Setenv("DATABASE_URL", connStr)
+}
+
+func initializeDaggerDB() {
+	log.Println("Using Dagger database")
+	os.Setenv("DATABASE_URL", "host=db user=testuser password=testpassword port=5432")
+}
+
+func globalSetup() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		initializeLocalDB()
+	} else if os.Getenv("ENV") == "CI" {
+		initializeDaggerDB()
+	} else {
+		log.Fatal("Unknown environment")
+	}
+	setUpTestDatabase()
+}
+
+func setUpTestDatabase() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		return
+	}
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	_, err = db.Exec("CREATE DATABASE alercedb")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Setenv("DATABASE_URL", os.Getenv("DATABASE_URL")+" dbname=alercedb")
+}
+
+func globalTeardown() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		CleanUpContainer(ctx, container)
+	}
+}
+
+func TestMain(m *testing.M) {
+	globalSetup()
+	code := m.Run()
+	globalTeardown()
+	os.Exit(code)
+}
+
+func restoreDatabase() {
+	db, err := GetDB(os.Getenv("DATABASE_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = DropTables(db)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/tapservicego/pkg/votable/votable.go
+++ b/tapservicego/pkg/votable/votable.go
@@ -96,3 +96,23 @@ type Row struct {
 type Column struct {
 	Value string `xml:",chardata"`
 }
+
+// NewVOTable creates a new VOTable from string
+func NewVOTableFromString(xmlRepr string) (*VOTable, error) {
+	var votable VOTable
+	err := xml.Unmarshal([]byte(xmlRepr), &votable)
+	if err != nil {
+		return nil, err
+	}
+	return &votable, nil
+}
+
+// NewVOTableFromBytes creates a new VOTable from bytes
+func NewVOTableFromBytes(xmlRepr []byte) (*VOTable, error) {
+	var votable VOTable
+	err := xml.Unmarshal(xmlRepr, &votable)
+	if err != nil {
+		return nil, err
+	}
+	return &votable, nil
+}

--- a/tapservicego/pkg/votable/votable_test.go
+++ b/tapservicego/pkg/votable/votable_test.go
@@ -13,11 +13,11 @@ func TestCreateVOTable(t *testing.T) {
 		Version: "1.4",
 		Xmlns:   "http://www.ivoa.net/xml/VOTable/v1.4",
 		Resource: Resource{
-			Type: "results",
+			Type:  "results",
 			Infos: []Info{{Name: "QUERY_STATUS", Value: "OK"}},
 			Tables: []Table{
 				{
-					Name: "results",
+					Name:        "results",
 					Description: "Results of the query",
 					Fields: []Field{
 						{Name: "RA", Datatype: "double", Unit: "deg"},
@@ -78,4 +78,45 @@ func TestCreateVOTable(t *testing.T) {
 	</RESOURCE>
 </VOTABLE>`
 	assert.Equal(t, expectedVOTableXML, votableXML)
+}
+
+func TestNewVotableFromString(t *testing.T) {
+	votableString := `<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.4">
+	<RESOURCE type="results">
+		<INFO name="QUERY_STATUS" value="OK"></INFO>
+		<TABLE name="results">
+			<DESCRIPTION>Results of the query</DESCRIPTION>
+			<FIELD name="RA" datatype="double" unit="deg"></FIELD>
+			<FIELD name="DEC" datatype="double" unit="deg"></FIELD>
+			<FIELD name="MAG" datatype="float" unit="mag">
+				<DESCRIPTION>Magnitude</DESCRIPTION>
+			</FIELD>
+			<DATA>
+				<TABLEDATA>
+					<TR>
+						<TD>10.0</TD>
+						<TD>20.0</TD>
+						<TD>15.0</TD>
+					</TR>
+					<TR>
+						<TD>20.0</TD>
+						<TD>30.0</TD>
+						<TD>16.0</TD>
+					</TR>
+					<TR>
+						<TD>30.0</TD>
+						<TD>40.0</TD>
+						<TD>17.0</TD>
+					</TR>
+				</TABLEDATA>
+			</DATA>
+		</TABLE>
+	</RESOURCE>
+</VOTABLE>`
+	votable, err := NewVOTableFromString(votableString)
+	if err != nil {
+		t.Errorf("Error parsing VOTable: %v", err)
+	}
+	assert.Equal(t, "OK", votable.Resource.Infos[0].Value)
+	assert.Equal(t, 3, len(votable.Resource.Tables[0].Data.TableData.Rows))
 }


### PR DESCRIPTION
## Big refactor !!

- Added alercedb package to simulate the ALeRCE PSQL Database (for ZTF).
- Added tests for all output types of sync queries with each database table

Notes:
- tests use testcontainers when running with the env variable `ENV` empty or `ENV=DEV`
- otherwise they use an external instance that should be running when the test starts
  - this instance is a dagger service
- two databases are created (inside the same instance) one for the pkg/alercedb package and one for the internal/tapsync package, to avoid conflicts between the two packages during tests
