### PR TITLE
refactor: singleton database instance for tests

### DIFF
--- a/tapservicego/internal/tapsync/alerce_suite_test.go
+++ b/tapservicego/internal/tapsync/alerce_suite_test.go
@@ -1,0 +1,108 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+type AlerceTestSuite struct {
+	suite.Suite
+	DB            *sql.DB
+	connUrl       string
+	PsqlContainer *postgres.PostgresContainer
+	ctx           context.Context
+	Service       *TapSyncService
+}
+
+func (suite *AlerceTestSuite) SetupSuite() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		suite.InitializeLocalDB()
+	} else if os.Getenv("ENV") == "CI" {
+		suite.InitializeDaggerDB()
+	} else {
+		suite.T().Fatal("Unknown environment")
+	}
+	suite.Service = NewTapSyncService()
+}
+
+func (suite *AlerceTestSuite) TearDownSuite() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		testhelpers.CleanUpContainer(suite.ctx, suite.PsqlContainer)
+	}
+	suite.DB.Close()
+}
+
+func (suite *AlerceTestSuite) SetupTest() {
+	suite.T().Log("Populating database")
+	err := testhelpers.PopulateALeRCEDB(suite.DB)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+}
+
+func (suite *AlerceTestSuite) TearDownTest() {
+	err := testhelpers.ClearALeRCEDB(suite.DB)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+}
+
+func TestAlerceTestSuite(t *testing.T) {
+	suite.Run(t, new(AlerceTestSuite))
+}
+
+func (suite *AlerceTestSuite) InitializeLocalDB() {
+	suite.T().Log("Using local database")
+	var err error
+	suite.ctx = context.Background()
+	suite.PsqlContainer, err = testhelpers.CreatePostgresContainer(suite.ctx, "alerce")
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	var connStr string
+	connStr, err = suite.PsqlContainer.ConnectionString(suite.ctx)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	suite.connUrl = connStr
+	os.Setenv("DATABASE_URL", connStr)
+	db, err := GetDB(connStr)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	suite.DB = db
+}
+
+func (suite *AlerceTestSuite) InitializeDaggerDB() {
+	suite.T().Log("Using Dagger database")
+	connUrl := "host=db user=testuser password=testpassword port=5432"
+	// create alerce database
+	db, err := GetDB(connUrl)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	_, err = db.Exec("CREATE DATABASE alerce")
+	if err != nil {
+		suite.T().Log("Could not create alerce database")
+		suite.T().Fatal(err)
+	}
+	db.Close()
+	// connect to alerce database
+	connUrl = connUrl + " dbname=alerce"
+	suite.connUrl = connUrl
+	os.Setenv("DATABASE_URL", connUrl)
+	db, err = GetDB(connUrl)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	suite.DB = db
+}

--- a/tapservicego/internal/tapsync/alercecsv_test.go
+++ b/tapservicego/internal/tapsync/alercecsv_test.go
@@ -1,256 +1,172 @@
 package tapsync
 
 import (
-	"ataps/internal/testhelpers"
 	"ataps/pkg/alercedb"
 	"encoding/csv"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
-func TestCsv(t *testing.T) {
-	test_get_csv_data_from_object := func(t *testing.T, table string, ensureObjectExistIn *string, overrideOid *string) [][]string {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		var oid string
-		if overrideOid == nil {
-			if ensureObjectExistIn == nil {
-				row := db.QueryRow("SELECT oid FROM object LIMIT 1")
-				if row.Err() != nil {
-					t.Fatal(row.Err())
-				}
-				row.Scan(&oid)
-			} else {
-				row := db.QueryRow(fmt.Sprintf("SELECT oid FROM %s LIMIT 1", *ensureObjectExistIn))
-				if row.Err() != nil {
-					t.Fatal(row.Err())
-				}
-				row.Scan(&oid)
+func test_get_csv_data_from_object(suite *AlerceTestSuite, table string, ensureObjectExistIn *string, overrideOid *string) [][]string {
+	var oid string
+	if overrideOid == nil {
+		if ensureObjectExistIn == nil {
+			row := suite.DB.QueryRow("SELECT oid FROM object LIMIT 1")
+			if row.Err() != nil {
+				suite.T().Fatal(row.Err())
 			}
+			row.Scan(&oid)
 		} else {
-			oid = *overrideOid
+			row := suite.DB.QueryRow(fmt.Sprintf("SELECT oid FROM %s LIMIT 1", *ensureObjectExistIn))
+			if row.Err() != nil {
+				suite.T().Fatal(row.Err())
+			}
+			row.Scan(&oid)
 		}
-		service := NewTapSyncService()
-		response := sendTestQuery(fmt.Sprintf("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM %s WHERE oid='%s'", table, oid), service)
-		require.Equal(t, http.StatusOK, response.Code)
-		reader := csv.NewReader(response.Body)
-		records, err := reader.ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		return records
+	} else {
+		oid = *overrideOid
 	}
+	response := SendTestQuery(fmt.Sprintf("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM %s WHERE oid='%s'", table, oid), suite.Service)
+	suite.Require().Equal(http.StatusOK, response.Code)
+	reader := csv.NewReader(response.Body)
+	records, err := reader.ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	return records
 
-	t.Run("TestCsv_Detections", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM detection LIMIT 1", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		columnNames := getColumnNames(alercedb.Detection{})
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
+}
 
-	})
+func (suite *AlerceTestSuite) TestCsv_Detections() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM detection LIMIT 1", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	columnNames := GetColumnNames(alercedb.Detection{})
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+}
 
-	t.Run("TestCsv_DetectionsFromAnObject", func(t *testing.T) {
-		ensureObjectExistIn := "detection"
-		records := test_get_csv_data_from_object(t, "detection", &ensureObjectExistIn, nil)
-		require.Greater(t, len(records), 1)
-	})
+func (suite *AlerceTestSuite) TestCsv_DetectionsFromAnObject() {
+	ensureObjectExistIn := "detection"
+	records := test_get_csv_data_from_object(suite, "detection", &ensureObjectExistIn, nil)
+	suite.Require().Greater(len(records), 1)
+}
 
-	t.Run("TestCsv_DetectionsFromUnknownObject", func(t *testing.T) {
-		var oid = "unknown"
-		records := test_get_csv_data_from_object(t, "detection", nil, &oid)
-		require.Equal(t, 0, len(records))
-	})
+func (suite *AlerceTestSuite) TestCsv_DetectionsFromUnknownObject() {
+	var oid = "unknown"
+	records := test_get_csv_data_from_object(suite, "detection", nil, &oid)
+	suite.Require().Equal(0, len(records))
+}
 
-	t.Run("TestCsv_NonDetection", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM non_detection LIMIT 1", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		columnNames := getColumnNames(alercedb.NonDetection{})
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
-	})
+func (suite *AlerceTestSuite) TestCsv_NonDetection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM non_detection LIMIT 1", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	columnNames := GetColumnNames(alercedb.NonDetection{})
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+}
 
-	t.Run("TestCsv_NonDetectionFromAnObject", func(t *testing.T) {
-		oidFrom := "non_detection"
-		records := test_get_csv_data_from_object(t, "non_detection", &oidFrom, nil)
-		require.Greater(t, len(records), 1)
-	})
+func (suite *AlerceTestSuite) TestCsv_NonDetectionFromAnObject() {
+	oidFrom := "non_detection"
+	records := test_get_csv_data_from_object(suite, "non_detection", &oidFrom, nil)
+	suite.Require().Greater(len(records), 1)
+}
 
-	t.Run("TestCsv_NonDetectionFromUnknownObject", func(t *testing.T) {
-		var oid = "unknown"
-		records := test_get_csv_data_from_object(t, "non_detection", nil, &oid)
-		require.Equal(t, 0, len(records))
-	})
+func (suite *AlerceTestSuite) TestCsv_NonDetectionFromUnknownObject() {
+	var oid = "unknown"
+	records := test_get_csv_data_from_object(suite, "non_detection", nil, &oid)
+	suite.Require().Equal(0, len(records))
+}
 
-	t.Run("TestCsv_ForcedPhotometry", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM forced_photometry LIMIT 1", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		columnNames := getColumnNames(alercedb.ForcedPhotometry{})
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
-	})
+func (suite *AlerceTestSuite) TestCsv_ForcedPhotometry() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM forced_photometry LIMIT 1", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	columnNames := GetColumnNames(alercedb.ForcedPhotometry{})
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+}
 
-	t.Run("TestCsv_ForcedPhotometryFromAnObject", func(t *testing.T) {
-		oidFrom := "forced_photometry"
-		records := test_get_csv_data_from_object(t, "forced_photometry", &oidFrom, nil)
-		require.Greater(t, len(records), 1)
-	})
+func (suite *AlerceTestSuite) TestCsv_ForcedPhotometryFromAnObject() {
+	oidFrom := "forced_photometry"
+	records := test_get_csv_data_from_object(suite, "forced_photometry", &oidFrom, nil)
+	suite.Require().Greater(len(records), 1)
+}
 
-	t.Run("TestCsv_ForcedPhotometryFromUnknownObject", func(t *testing.T) {
-		var oid = "unknown"
-		records := test_get_csv_data_from_object(t, "forced_photometry", nil, &oid)
-		require.Equal(t, 0, len(records))
-	})
+func (suite *AlerceTestSuite) TestCsv_ForcedPhotometryFromUnknownObject() {
+	var oid = "unknown"
+	records := test_get_csv_data_from_object(suite, "forced_photometry", nil, &oid)
+	suite.Require().Equal(0, len(records))
+}
 
-	t.Run("TestCsv_Features", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM feature LIMIT 1", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		columnNames := getColumnNames(alercedb.Feature{})
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
-	})
+func (suite *AlerceTestSuite) TestCsv_Features() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM feature LIMIT 1", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	columnNames := GetColumnNames(alercedb.Feature{})
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+}
 
-	t.Run("TestCsv_FeaturesFromAnObject", func(t *testing.T) {
-		oidFrom := "feature"
-		records := test_get_csv_data_from_object(t, "feature", &oidFrom, nil)
-		require.Greater(t, len(records), 1)
-	})
+func (suite *AlerceTestSuite) TestCsv_FeaturesFromAnObject() {
+	oidFrom := "feature"
+	records := test_get_csv_data_from_object(suite, "feature", &oidFrom, nil)
+	suite.Require().Greater(len(records), 1)
+}
 
-	t.Run("TestCsv_FeaturesFromUnknownObject", func(t *testing.T) {
-		var oid = "unknown"
-		records := test_get_csv_data_from_object(t, "feature", nil, &oid)
-		require.Equal(t, 0, len(records))
-	})
+func (suite *AlerceTestSuite) TestCsv_FeaturesFromUnknownObject() {
+	var oid = "unknown"
+	records := test_get_csv_data_from_object(suite, "feature", nil, &oid)
+	suite.Require().Equal(0, len(records))
+}
 
-	t.Run("TestCsv_Objects", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM object LIMIT 2", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		columnNames := getColumnNames(alercedb.Object{})
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
-		require.Equal(t, 3, len(records)) // header + 2 objects
-	})
+func (suite *AlerceTestSuite) TestCsv_Objects() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM object LIMIT 2", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	columnNames := GetColumnNames(alercedb.Object{})
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+	suite.Require().Equal(3, len(records)) // header + 2 objects
+}
 
-	t.Run("TestCsv_Probabilities", func(t *testing.T) {
-		db, err := GetDB(os.Getenv("DATABASE_URL"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		testhelpers.ClearALeRCEDB(db)
-		err = testhelpers.PopulateALeRCEDB(db)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-		service := NewTapSyncService()
-		w := sendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM probability LIMIT 1", service)
-		require.Equal(t, http.StatusOK, w.Code)
-		require.Equal(t, "text/csv", w.Header().Get("Content-Type"))
-		columnNames := getColumnNames(alercedb.Probability{})
-		records, err := csv.NewReader(w.Body).ReadAll()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sort.Strings(columnNames)
-		require.Equal(t, columnNames, records[0])
-	})
+func (suite *AlerceTestSuite) TestCsv_Probabilities() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=csv&&QUERY=SELECT * FROM probability LIMIT 1", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/csv", w.Header().Get("Content-Type"))
+	columnNames := GetColumnNames(alercedb.Probability{})
+	records, err := csv.NewReader(w.Body).ReadAll()
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	sort.Strings(columnNames)
+	suite.Require().Equal(columnNames, records[0])
+}
 
-	t.Run("TestCsv_ProbabilitiesFromAnObject", func(t *testing.T) {
-		oidFrom := "probability"
-		records := test_get_csv_data_from_object(t, "probability", &oidFrom, nil)
-		require.Greater(t, len(records), 1)
-	})
+func (suite *AlerceTestSuite) TestCsv_ProbabilitiesFromAnObject() {
+	oidFrom := "probability"
+	records := test_get_csv_data_from_object(suite, "probability", &oidFrom, nil)
+	suite.Require().Greater(len(records), 1)
 }

--- a/tapservicego/internal/tapsync/alercehtml_test.go
+++ b/tapservicego/internal/tapsync/alercehtml_test.go
@@ -1,37 +1,22 @@
 package tapsync
 
 import (
-	"ataps/internal/testhelpers"
 	"ataps/pkg/alercedb"
 	"net/http"
-	"os"
-	"testing"
 
-	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
 )
 
-func TestHtml_Object(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM object LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_Object() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM object LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -40,38 +25,26 @@ func TestHtml_Object(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Object{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Object{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestHtml_NonExistentTable(t *testing.T) {
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_existent_table LIMIT 3", service)
-	require.Equal(t, http.StatusInternalServerError, w.Code)
+func (suite *AlerceTestSuite) TestHtml_NonExistentTable() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_existent_table LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusInternalServerError, w.Code)
 }
 
-func TestHtml_Detection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_Detection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -80,32 +53,21 @@ func TestHtml_Detection(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Detection{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Detection{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestHtml_NonDetection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_NonDetection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM non_detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -114,32 +76,21 @@ func TestHtml_NonDetection(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.NonDetection{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.NonDetection{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestHtml_ForcedPhotometry(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_ForcedPhotometry() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM forced_photometry LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -148,32 +99,21 @@ func TestHtml_ForcedPhotometry(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.ForcedPhotometry{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestHtml_Features(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM feature LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_Features() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM feature LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -182,32 +122,21 @@ func TestHtml_Features(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Feature{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Feature{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestHtml_Probabilities(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM probability LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/html", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestHtml_Probabilities() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=html&&QUERY=SELECT * FROM probability LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/html", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
 	doc, err := html.Parse(w.Body)
-	require.NoError(t, err)
-	parseHTMLTable(doc, &headers, "th")
-	parseHTMLTable(doc, &data, "td")
+	suite.Require().NoError(err)
+	ParseHTMLTable(doc, &headers, "th")
+	ParseHTMLTable(doc, &data, "td")
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -216,7 +145,7 @@ func TestHtml_Probabilities(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Probability{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Probability{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }

--- a/tapservicego/internal/tapsync/alercetext_test.go
+++ b/tapservicego/internal/tapsync/alercetext_test.go
@@ -1,34 +1,18 @@
 package tapsync
 
 import (
-	"ataps/internal/testhelpers"
 	"ataps/pkg/alercedb"
 	"net/http"
-	"os"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
-func TestText_Object(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM object LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_Object() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM object LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -37,30 +21,19 @@ func TestText_Object(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Object{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Object{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestText_Detection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_Detection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -69,30 +42,19 @@ func TestText_Detection(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Detection{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Detection{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestText_NonDetection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_NonDetection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM non_detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -101,30 +63,19 @@ func TestText_NonDetection(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.NonDetection{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.NonDetection{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestText_ForcedPhotometry(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_ForcedPhotometry() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM forced_photometry LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -133,30 +84,19 @@ func TestText_ForcedPhotometry(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.ForcedPhotometry{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestText_Features(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM feature LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_Features() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM feature LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -165,30 +105,19 @@ func TestText_Features(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Feature{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Feature{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }
 
-func TestText_Probabilities(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM probability LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "text/plain", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestText_Probabilities() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=text&&QUERY=SELECT * FROM probability LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("text/plain", w.Header().Get("Content-Type"))
 	var data []string
 	var headers []string
-	err = parseTextTable(w.Body.String(), &data, &headers)
-	require.NoError(t, err)
+	err := ParseTextTable(w.Body.String(), &data, &headers)
+	suite.Require().NoError(err)
 	var rows []map[string]string
 	for i := 0; i < len(data); i += len(headers) {
 		row := make(map[string]string)
@@ -197,7 +126,7 @@ func TestText_Probabilities(t *testing.T) {
 		}
 		rows = append(rows, row)
 	}
-	require.Len(t, rows, 3)
-	columnNames := getColumnNames(alercedb.Probability{})
-	require.ElementsMatch(t, headers, columnNames)
+	suite.Require().Len(rows, 3)
+	columnNames := GetColumnNames(alercedb.Probability{})
+	suite.Require().ElementsMatch(headers, columnNames)
 }

--- a/tapservicego/internal/tapsync/alercevotable_test.go
+++ b/tapservicego/internal/tapsync/alercevotable_test.go
@@ -1,162 +1,91 @@
 package tapsync
 
 import (
-	"ataps/internal/testhelpers"
 	"ataps/pkg/alercedb"
 	"ataps/pkg/votable"
 	"net/http"
-	"os"
-	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
-func TestVotable_Object(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM object LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_Object() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM object LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.Object{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.Object{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }
 
-func TestVotable_Detection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_Detection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.Detection{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.Detection{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }
 
-func TestVotable_NonDetection(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM non_detection LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_NonDetection() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM non_detection LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.NonDetection{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.NonDetection{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }
 
-func TestVotable_ForcedPhotometry(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM forced_photometry LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_ForcedPhotometry() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM forced_photometry LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.ForcedPhotometry{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.ForcedPhotometry{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }
 
-func TestVotable_Features(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM feature LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_Features() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM feature LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.Feature{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.Feature{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }
 
-func TestVotable_Probabilities(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	testhelpers.ClearALeRCEDB(db)
-	err = testhelpers.PopulateALeRCEDB(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	service := NewTapSyncService()
-	w := sendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM probability LIMIT 3", service)
-	require.Equal(t, http.StatusOK, w.Code)
-	require.Equal(t, "application/x-votable+xml", w.Header().Get("Content-Type"))
+func (suite *AlerceTestSuite) TestVotable_Probabilities() {
+	w := SendTestQuery("LANG=PSQL&&FORMAT=votable&&QUERY=SELECT * FROM probability LIMIT 3", suite.Service)
+	suite.Require().Equal(http.StatusOK, w.Code)
+	suite.Require().Equal("application/x-votable+xml", w.Header().Get("Content-Type"))
 	voTable, err := votable.NewVOTableFromString(w.Body.String())
-	require.NoError(t, err)
-	columnNames := getColumnNames(alercedb.Probability{})
-	require.Len(t, voTable.Resource.Tables[0].Fields, len(columnNames))
+	suite.Require().NoError(err)
+	columnNames := GetColumnNames(alercedb.Probability{})
+	suite.Require().Len(voTable.Resource.Tables[0].Fields, len(columnNames))
 	for _, field := range voTable.Resource.Tables[0].Fields {
-		require.Contains(t, columnNames, field.Name)
+		suite.Require().Contains(columnNames, field.Name)
 	}
-	require.Len(t, voTable.Resource.Tables[0].Data.TableData.Rows, 3)
+	suite.Require().Len(voTable.Resource.Tables[0].Data.TableData.Rows, 3)
 }

--- a/tapservicego/internal/tapsync/psqlrepository_test.go
+++ b/tapservicego/internal/tapsync/psqlrepository_test.go
@@ -2,40 +2,27 @@ package tapsync
 
 import (
 	"ataps/internal/testhelpers"
-	"os"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-
-func TestSimpleSQLQuery(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		t.Fatal(err)
-	}
+func (suite *TapSyncTestSuite) TestSimpleSQLQuery() {
 	query := "SELECT 'test'"
-	result, err := HandleSQLQuery(query, db)
+	result, err := HandleSQLQuery(query, suite.DB)
 	if err != nil {
-		t.Fatal(err)
+		suite.T().Fatal(err)
 	}
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "test", result[0]["?column?"])
+	suite.Equal(1, len(result))
+	suite.Equal("test", result[0]["?column?"])
 }
 
-func TestHandleSQLQuery(t *testing.T) {
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	testhelpers.PopulateDb(db)
-	defer testhelpers.ClearDataFromTable(db)
-	if err != nil {
-		t.Fatal(err)
-	}
+func (suite *TapSyncTestSuite) TestHandleSQLQuery() {
+	testhelpers.PopulateDb(suite.DB)
+	defer testhelpers.ClearDataFromTable(suite.DB)
 	query := "SELECT * FROM test"
-	result, err := HandleSQLQuery(query, db)
+	result, err := HandleSQLQuery(query, suite.DB)
 	if err != nil {
-		t.Fatal(err)
+		suite.T().Fatal(err)
 	}
-	assert.Equal(t, 1, len(result))
-	assert.Equal(t, "test", result[0]["name"])
-	assert.Equal(t, int64(1), result[0]["number"])
+	suite.Equal(1, len(result))
+	suite.Equal("test", result[0]["name"])
+	suite.Equal(int64(1), result[0]["number"])
 }

--- a/tapservicego/internal/tapsync/tapsync_suite_test.go
+++ b/tapservicego/internal/tapsync/tapsync_suite_test.go
@@ -1,0 +1,99 @@
+package tapsync
+
+import (
+	"ataps/internal/testhelpers"
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+type TapSyncTestSuite struct {
+	suite.Suite
+	DB            *sql.DB
+	connUrl       string
+	PsqlContainer *postgres.PostgresContainer
+	ctx           context.Context
+	Service       *TapSyncService
+}
+
+func (suite *TapSyncTestSuite) SetupSuite() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		suite.InitializeLocalDB()
+	} else if os.Getenv("ENV") == "CI" {
+		suite.InitializeDaggerDB()
+	} else {
+		suite.T().Fatal("Unknown environment")
+	}
+	suite.Service = NewTapSyncService()
+}
+
+func (suite *TapSyncTestSuite) TearDownSuite() {
+	if os.Getenv("ENV") == "DEV" || os.Getenv("ENV") == "" {
+		testhelpers.CleanUpContainer(suite.ctx, suite.PsqlContainer)
+	}
+	suite.DB.Close()
+}
+
+func (suite *TapSyncTestSuite) SetupTest() {
+}
+
+func (suite *TapSyncTestSuite) TearDownTest() {
+}
+
+func TestTapSyncTestSuite(t *testing.T) {
+	suite.Run(t, new(TapSyncTestSuite))
+}
+
+func (suite *TapSyncTestSuite) InitializeLocalDB() {
+	suite.T().Log("Using local database")
+	var err error
+	suite.ctx = context.Background()
+	suite.PsqlContainer, err = testhelpers.CreatePostgresContainer(suite.ctx, "tapsync")
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	var connStr string
+	connStr, err = suite.PsqlContainer.ConnectionString(suite.ctx)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+	suite.connUrl = connStr
+	os.Setenv("DATABASE_URL", connStr)
+	db, err := GetDB(connStr)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	suite.DB = db
+}
+
+func (suite *TapSyncTestSuite) InitializeDaggerDB() {
+	suite.T().Log("Using Dagger database")
+	connUrl := "host=db user=testuser password=testpassword port=5432"
+	// create tapsync database
+	db, err := GetDB(connUrl)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	_, err = db.Exec("CREATE DATABASE tapsync")
+	if err != nil {
+		suite.T().Log("Could not create tapsync database")
+		suite.T().Fatal(err)
+	}
+	db.Close()
+	// connect to tapsync database
+	connUrl = connUrl + " dbname=tapsync"
+	suite.connUrl = connUrl
+	os.Setenv("DATABASE_URL", connUrl)
+	db, err = GetDB(connUrl)
+	if err != nil {
+		suite.T().Log("Could not connect")
+		suite.T().Fatal(err)
+	}
+	suite.DB = db
+}

--- a/tapservicego/internal/tapsync/utils_test.go
+++ b/tapservicego/internal/tapsync/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/html"
 )
 
-func sendTestQuery(query string, service *TapSyncService) *httptest.ResponseRecorder {
+func SendTestQuery(query string, service *TapSyncService) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(
 		"POST",
@@ -22,7 +22,7 @@ func sendTestQuery(query string, service *TapSyncService) *httptest.ResponseReco
 	return w
 }
 
-func getColumnNames(v interface{}) []string {
+func GetColumnNames(v interface{}) []string {
 	t := reflect.TypeOf(v)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -44,7 +44,7 @@ func getColumnNames(v interface{}) []string {
 	return fieldNames
 }
 
-func parseHTMLTable(doc *html.Node, data *[]string, tag string) {
+func ParseHTMLTable(doc *html.Node, data *[]string, tag string) {
 	var traverse func(n *html.Node, tag string) *html.Node
 	traverse = func(n *html.Node, tag string) *html.Node {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
@@ -61,7 +61,7 @@ func parseHTMLTable(doc *html.Node, data *[]string, tag string) {
 	traverse(doc, tag)
 }
 
-func parseTextTable(doc string, data *[]string, headers *[]string) error {
+func ParseTextTable(doc string, data *[]string, headers *[]string) error {
 	scanner := bufio.NewScanner(strings.NewReader(doc))
 	isHeader := false
 	for scanner.Scan() {

--- a/tapservicego/internal/testhelpers/populatepsql.go
+++ b/tapservicego/internal/testhelpers/populatepsql.go
@@ -3,6 +3,7 @@ package testhelpers
 import (
 	"ataps/pkg/alercedb"
 	"database/sql"
+	"log"
 )
 
 func PopulateDb(db *sql.DB) error {
@@ -28,30 +29,37 @@ func ClearDataFromTable(db *sql.DB) error {
 func PopulateALeRCEDB(db *sql.DB) error {
 	err := alercedb.CreateTables(db)
 	if err != nil {
+		log.Println("Error creating tables")
 		return err
 	}
 	oidPool, err := alercedb.InsertSampleObjects(db, 100)
 	if err != nil {
+		log.Println("Error inserting sample objects")
 		return err
 	}
 	err = alercedb.InsertSampleDetections(db, 1000, oidPool)
 	if err != nil {
+		log.Println("Error inserting sample detections")
 		return err
 	}
 	err = alercedb.InsertSampleNonDetections(db, 1000, oidPool)
 	if err != nil {
+		log.Println("Error inserting sample non detections")
 		return err
 	}
 	err = alercedb.InsertSampleForcedPhotometry(db, 1000, oidPool)
 	if err != nil {
+		log.Println("Error inserting sample forced photometry")
 		return err
 	}
 	err = alercedb.InsertSampleFeatures(db, 100, oidPool)
 	if err != nil {
+		log.Println("Error inserting sample features")
 		return err
 	}
 	err = alercedb.InsertSampleProbabilities(db, oidPool, []string{"SN", "AGN", "VS", "Asteroid", "Bogus"}, "stamp_classifier")
 	if err != nil {
+		log.Println("Error inserting sample probabilities")
 		return err
 	}
 	return nil

--- a/tapservicego/main.go
+++ b/tapservicego/main.go
@@ -5,6 +5,7 @@ import (
 )
 
 func main() {
-    r := tapsync.NewTapSyncService()
-    r.Router.Run()
+	r := tapsync.NewTapSyncService()
+	r.Router.Run()
+	r.DB.Close()
 }

--- a/tapservicego/pkg/alercedb/inserts_test.go
+++ b/tapservicego/pkg/alercedb/inserts_test.go
@@ -1,127 +1,89 @@
 package alercedb
 
-import (
-	"log"
-	"os"
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
-
-func TestInsertSampleObjects(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	_, err = InsertSampleObjects(db, 10)
+func (suite *AlerceSuite) TestInsertSampleObjects() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	_, err = InsertSampleObjects(suite.DB, 10)
 	query := `SELECT COUNT(*) FROM object;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, 10, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(10, count)
 }
 
-func TestInsertSampleDetections(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	oidPool, err := InsertSampleObjects(db, 10)
-	require.Nil(t, err)
-	err = InsertSampleDetections(db, 100, oidPool)
-	require.Nil(t, err)
+func (suite *AlerceSuite) TestInsertSampleDetections() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	oidPool, err := InsertSampleObjects(suite.DB, 10)
+	suite.Require().Nil(err)
+	err = InsertSampleDetections(suite.DB, 100, oidPool)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM detection;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, 100, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(100, count)
 }
 
-func TestInsertSampleNonDetections(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	oidPool, err := InsertSampleObjects(db, 10)
-	require.Nil(t, err)
-	err = InsertSampleNonDetections(db, 100, oidPool)
-	require.Nil(t, err)
+func (suite *AlerceSuite) TestInsertSampleNonDetections() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	oidPool, err := InsertSampleObjects(suite.DB, 10)
+	suite.Require().Nil(err)
+	err = InsertSampleNonDetections(suite.DB, 100, oidPool)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM non_detection;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, 100, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(100, count)
 }
 
-func TestInsertSampleForcedPhotometry(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	oidPool, err := InsertSampleObjects(db, 10)
-	require.Nil(t, err)
-	err = InsertSampleForcedPhotometry(db, 100, oidPool)
-	require.Nil(t, err)
+func (suite *AlerceSuite) TestInsertSampleForcedPhotometry() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	oidPool, err := InsertSampleObjects(suite.DB, 10)
+	suite.Require().Nil(err)
+	err = InsertSampleForcedPhotometry(suite.DB, 100, oidPool)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM forced_photometry;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, 100, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(100, count)
 }
 
-func TestInsertSampleFeatures(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	oidPool, err := InsertSampleObjects(db, 10)
-	require.Nil(t, err)
-	err = InsertSampleFeatures(db, 100, oidPool)
-	require.Nil(t, err)
+func (suite *AlerceSuite) TestInsertSampleFeatures() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	oidPool, err := InsertSampleObjects(suite.DB, 10)
+	suite.Require().Nil(err)
+	err = InsertSampleFeatures(suite.DB, 100, oidPool)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM feature;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, 100, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(100, count)
 }
 
-func TestInsertSampleProbabilities(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	require.Nil(t, err)
-	oidPool, err := InsertSampleObjects(db, 10)
-	require.Nil(t, err)
+func (suite *AlerceSuite) TestInsertSampleProbabilities() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	oidPool, err := InsertSampleObjects(suite.DB, 10)
+	suite.Require().Nil(err)
 	classPool := []string{"class1", "class2", "class3"}
-	err = InsertSampleProbabilities(db, oidPool, classPool, "classifier")
-	require.Nil(t, err)
+	err = InsertSampleProbabilities(suite.DB, oidPool, classPool, "classifier")
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM probability;`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	require.Nil(t, err)
-	require.Equal(t, len(classPool)*len(oidPool), count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(len(classPool)*len(oidPool), count)
 }

--- a/tapservicego/pkg/alercedb/tables.go
+++ b/tapservicego/pkg/alercedb/tables.go
@@ -3,31 +3,38 @@ package alercedb
 import (
 	"database/sql"
 	"fmt"
+	"log"
 )
 
 func CreateTables(db *sql.DB) error {
 	err := createObjectTable(db)
 	if err != nil {
+		log.Println("Error creating object table")
 		return err
 	}
 	err = createDetectionsTable(db)
 	if err != nil {
+		log.Println("Error creating detections table")
 		return err
 	}
 	err = createNonDetectionsTable(db)
 	if err != nil {
+		log.Println("Error creating non detections table")
 		return err
 	}
 	err = createForcedPhotometryTable(db)
 	if err != nil {
+		log.Println("Error creating forced photometry table")
 		return err
 	}
 	err = createFeaturesTable(db)
 	if err != nil {
+		log.Println("Error creating features table")
 		return err
 	}
 	err = createProbabilitiesTable(db)
 	if err != nil {
+		log.Println("Error creating probabilities table")
 		return err
 	}
 	return nil

--- a/tapservicego/pkg/alercedb/tables_test.go
+++ b/tapservicego/pkg/alercedb/tables_test.go
@@ -1,218 +1,149 @@
 package alercedb
 
 import (
-	"database/sql"
-	"log"
-	"os"
-	"testing"
-
 	_ "github.com/jackc/pgx/v5/stdlib"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateTables(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = CreateTables(db)
-	assert.Nil(t, err)
-	assertTableExists("object", db, t)
-	assertTableExists("detection", db, t)
-	assertTableExists("non_detection", db, t)
+func (suite *AlerceSuite) TestCreateTables() {
+	RestoreDatabase(suite.DB, suite)
+	err := CreateTables(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("object")
+	suite.assertTableExists("detection")
+	suite.assertTableExists("non_detection")
 }
 
-func TestCreateObjectsTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	assert.Nil(t, err)
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	assertTableExists("object", db, t)
+func (suite *AlerceSuite) TestCreateObjectsTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("object")
 }
 
-func TestCreateObjectsTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateObjectsTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'object'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 5, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(5, count)
 }
 
-func TestCreateDetectionsTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createDetectionsTable(db)
-	assert.Nil(t, err)
-	assertTableExists("detection", db, t)
+func (suite *AlerceSuite) TestCreateDetectionsTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createDetectionsTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("detection")
 }
 
-func TestCreateDetectionsTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createDetectionsTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateDetectionsTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createDetectionsTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'detection'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(2, count)
 }
 
-func TestCreateNonDetectionsTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createNonDetectionsTable(db)
-	assert.Nil(t, err)
-	assertTableExists("non_detection", db, t)
+func (suite *AlerceSuite) TestCreateNonDetectionsTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createNonDetectionsTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("non_detection")
 }
 
-func TestCreateNonDetectionsTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createNonDetectionsTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateNonDetectionsTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createNonDetectionsTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'non_detection'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(2, count)
 }
 
-func TestCreateForcedPhotometryTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createForcedPhotometryTable(db)
-	assert.Nil(t, err)
-	assertTableExists("forced_photometry", db, t)
+func (suite *AlerceSuite) TestCreateForcedPhotometryTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createForcedPhotometryTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("forced_photometry")
 }
-func TestCreateForcedPhotometryTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createForcedPhotometryTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateForcedPhotometryTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createForcedPhotometryTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'forced_photometry'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(2, count)
 }
 
-func TestCreateFeatureTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createFeaturesTable(db)
-	assert.Nil(t, err)
-	assertTableExists("feature", db, t)
+func (suite *AlerceSuite) TestCreateFeatureTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createFeaturesTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("feature")
 }
 
-func TestCreateFeatureTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createFeaturesTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateFeatureTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createFeaturesTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'feature'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 2, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(2, count)
 }
 
-func TestCreateProbabilityTable(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createProbabilitiesTable(db)
-	assert.Nil(t, err)
-	assertTableExists("probability", db, t)
+func (suite *AlerceSuite) TestCreateProbabilityTable() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createProbabilitiesTable(suite.DB)
+	suite.Require().Nil(err)
+	suite.assertTableExists("probability")
 }
 
-func TestCreateProbabilityTableIndex(t *testing.T) {
-	restoreDatabase()
-	db, err := GetDB(os.Getenv("DATABASE_URL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	err = createObjectTable(db)
-	assert.Nil(t, err)
-	err = createProbabilitiesTable(db)
-	assert.Nil(t, err)
+func (suite *AlerceSuite) TestCreateProbabilityTableIndex() {
+	RestoreDatabase(suite.DB, suite)
+	err := createObjectTable(suite.DB)
+	suite.Require().Nil(err)
+	err = createProbabilitiesTable(suite.DB)
+	suite.Require().Nil(err)
 	query := `SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'probability'`
 	var count int
-	err = db.QueryRow(query).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 5, count)
+	err = suite.DB.QueryRow(query).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(5, count)
 }
 
-func assertTableExists(tableName string, db *sql.DB, t *testing.T) {
+func (suite *AlerceSuite) assertTableExists(tableName string) {
 	query := `SELECT COUNT(*) FROM information_schema.tables WHERE table_name = $1;`
 	var count int
-	err := db.QueryRow(query, tableName).Scan(&count)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, count)
+	err := suite.DB.QueryRow(query, tableName).Scan(&count)
+	suite.Require().Nil(err)
+	suite.Require().Equal(1, count)
 }


### PR DESCRIPTION
Taking advantage of `testify/suite` package to perform setup and teardown procedures for tests while keeping a single `sql.DB` instance for the entire test suite.