### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+# Issues relacionados
+Si existen issues agrégalos acá. Si el issue, historia de usuario, tarjeta, lo que sea, está en otra plataforma, agrégalo también acá.
+Lo importante es especificar el objetivo final para el que estamos trabajando o están directamente relacionados con este PR.
+
+# Descripción del problema
+Explicar en qué consiste el problema abordado en este PR. Se puede linkear algún documento si es que este existe.
+
+# Qué se hizo para resolverlo
+Explica cómo abordaste el problema y qué hiciste para resolverlo. No expliques código y evita repetir lo mismo que ya está explícito en el código.


### PR DESCRIPTION
# Issues relacionados
No hay

# Descripción del problema
Hace falta una guía para asegurar que el contenido de un PR está correctamente explicado y facilita el entendimiento para la persona que va a revisar.

# Qué se hizo para resolverlo
Se agregó un archivo markdown con el template para todos los PR. Se supone que los archivos en la carpeta `.github` con el nombre `pull_request_template.md` se asocian automáticamente al momento de crear un nuevo PR.

Ver [documentación](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)